### PR TITLE
add jpeg support for org-attachment

### DIFF
--- a/ox-blog.el
+++ b/ox-blog.el
@@ -503,7 +503,7 @@ By default, org page only publish that has changed. When prefix means force publ
          )
         ("blog-static"
          :base-directory ,ox-blog-base-directory
-         :base-extension "jpg\\|png\\|css\\|js\\|ico\\|gif\\|pdf\\|ogg"
+         :base-extension "jpeg\\|jpg\\|png\\|css\\|js\\|ico\\|gif\\|pdf\\|ogg"
          :recursive t
          :publishing-directory ,ox-blog-publishing-directory
          :publishing-function org-publish-attachment


### PR DESCRIPTION
Now, when I use org-download to add a file with jpeg postfix, the generated blog will not contain that file.